### PR TITLE
Pandas2

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -15,7 +15,7 @@ ignore-patterns=ref.*?py
 
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().
-init-hook="from pylint.config import find_pylintrc; import os, sys; sys.path.append(os.path.dirname(find_pylintrc()))"
+init-hook="from pylint.config import find_default_config_files; import os, sys; sys.path.append(os.path.dirname(list(find_default_config_files())[0]))"
 
 # Use multiple processes to speed up Pylint.
 jobs=1

--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
     - geopandas>=0.12.2,<1
     - h5py>=3.8.0,<4
     - numpy>=1.22.3,<2
-    - pandas>=1.5.3,<2
+    - pandas>=1.5.3,<3
     - pandarallel>=1.6.1,<2
     - pint>=0.19.2,<1
     - plotly>=5.13.0,<6

--- a/tests/test_cli/test_cli.py
+++ b/tests/test_cli/test_cli.py
@@ -148,8 +148,9 @@ def test_unpack_turbines_results(
         output_df_no_geoms,
         check_exact=False,
         rtol=0.001)
-    assert correct_df.geom_almost_equals(output_df).all(),\
-        "Geometries are not the same."
+    assert correct_df.geom_equals_exact(
+        output_df, tolerance=1e-6, align=True
+    ).all(), "Geometries are not the same."
 
 
 @pytest.mark.filterwarnings("ignore:Skipping")


### PR DESCRIPTION
Updates dependencies to support use of `pandas>=2.0`. This is necessary to avoid dependency conflicts between `reView` and many other packages.

Automated tests all seem to be passing, but manual testing of the `dash` app has not been performed.