### PR TITLE
Avoid df/str copies and unneeded iterables

### DIFF
--- a/reView/utils/bespoke.py
+++ b/reView/utils/bespoke.py
@@ -87,11 +87,7 @@ class BespokeUnpacker:
             self.src_crs,
             always_xy=True
         )
-        lons, lats = transformer.transform(xs, ys)
-        rdf["longitude"] = lons
-        rdf["latitude"] = lats
-        del rdf["x"]
-        del rdf["y"]
+        rdf[['longitude', 'latitude']] = transformer.transform(xs, ys)
         rdf = rdf[self.df.columns]
         return rdf
 
@@ -179,7 +175,8 @@ def batch_unpack_from_supply_curve(sc_df, n_workers=1):
         Parameters
         ----------
         sc_df : pd.core.frame.DataFrame
-            A reV supply curve pandas data frame.
+            A reV supply curve pandas data frame. This will get modified in
+            place.
         n_workers : int
             Number of workers to use for parallel processing.
             Default is 1 which will run in serial (and will be slow).
@@ -193,8 +190,7 @@ def batch_unpack_from_supply_curve(sc_df, n_workers=1):
     """
 
     # cap nb_workers to the total CPUs on the machine/node
-    if n_workers > cpu_count():
-        n_workers = cpu_count()
+    n_workers = min(cpu_count(), n_workers)
 
     if n_workers > 1:
         # initialize functionality for parallela dataframe.apply
@@ -202,43 +198,55 @@ def batch_unpack_from_supply_curve(sc_df, n_workers=1):
             progress_bar=True, nb_workers=n_workers, use_memory_fs=False)
 
     # filter out supply curve points with no capacity (i.e., no turbines)
-    sc_developable_df = sc_df[sc_df['capacity'] > 0].copy()
+    sc_df = sc_df[sc_df['capacity'] > 0]
     # reset the index because otherwise the unpacker will get messed up
-    sc_developable_df.reset_index(drop=True, inplace=True)
+    sc_df.reset_index(drop=True, inplace=True)
 
     # unpack the turbine coordinates
     if n_workers > 1:
         # run in parallel
-        all_turbines = sc_developable_df.parallel_apply(
+        all_turbines = sc_df.parallel_apply(
             lambda row:
                 BespokeUnpacker(
-                    sc_developable_df,
+                    sc_df,
                     sc_point_gid=row['sc_point_gid']
                 ).unpack_turbines(drop_sc_points=True),
             axis=1
         )
     else:
         # run in serial
-        all_turbines = sc_developable_df.apply(
+        all_turbines = sc_df.apply(
             lambda row:
                 BespokeUnpacker(
-                    sc_developable_df,
+                    sc_df,
                     sc_point_gid=row['sc_point_gid']
                 ).unpack_turbines(drop_sc_points=True),
             axis=1
         )
 
     # stack the results back into a single df
-    all_turbines_df = pd.concat(all_turbines.tolist())
+    all_turbines_df = pd.concat(all_turbines.values)
 
     # extract the geometries
-    all_turbines_df['geometry'] = all_turbines_df.apply(
-        lambda row: geometry.Point(
-            row['longitude'],
-            row['latitude']
-        ),
-        axis=1
-    )
+    if n_workers > 1:
+        # run in parallel
+        all_turbines_df['geometry'] = all_turbines_df.parallel_apply(
+            lambda row: geometry.Point(
+                row['longitude'],
+                row['latitude']
+            ),
+            axis=1
+        )
+    else:
+        # run in serial
+        all_turbines_df['geometry'] = all_turbines_df.apply(
+            lambda row: geometry.Point(
+                row['longitude'],
+                row['latitude']
+            ),
+            axis=1
+        )
+
     # turn into a geodataframe
     all_turbines_gdf = gpd.GeoDataFrame(all_turbines_df, crs='EPSG:4326')
 

--- a/reView/utils/characterizations.py
+++ b/reView/utils/characterizations.py
@@ -72,16 +72,13 @@ def recast_categories(df, col, lkup, cell_size_sq_km):
     col_df = pd.DataFrame(col_data)
     col_df.fillna(0, inplace=True)
     col_df.drop(
-        columns=[c for c in col_df.columns if c not in lkup.keys()],
+        columns=[c for c in col_df.columns if c not in lkup],
         inplace=True
     )
     col_df.rename(columns=lkup, inplace=True)
     if cell_size_sq_km is not None:
         col_df *= cell_size_sq_km
-        col_df.rename(
-            columns={c: f"{c}_area_sq_km" for c in col_df.columns},
-            inplace=True
-        )
+        col_df.columns += "_area_sq_km"
 
     col_df.index = df.index
 
@@ -216,14 +213,12 @@ def validate_characterization_remapper(  # noqa: C901
         parameters are encountered in characterization_remapper.
     """
 
-    characterization_cols = list(characterization_remapper.keys())
-    df_cols = supply_curve_df.columns.tolist()
-    cols_not_in_df = list(set(characterization_cols).difference(set(df_cols)))
-    if len(cols_not_in_df) > 0:
+    if any(key not in df.columns for key in characterization_remapper):
+        keys = [key not in df.columns for key in characterization_remapper]
         raise KeyError(
             "Invalid column name(s) in characterization_remapper. "
             "The following column name(s) were not found in the input "
-            f"dataframe: {cols_not_in_df}."
+            f"dataframe: {keys}."
         )
 
     for col_name, col_remapper in characterization_remapper.items():

--- a/reView/utils/functions.py
+++ b/reView/utils/functions.py
@@ -695,9 +695,9 @@ def to_geo(df, dst, layer):
     if "index" in df:
         del df["index"]
 
+    # Remove or rename columns
     replace_columns = False
     new_columns = []
-    # Remove or rename columns
     for col in df.columns:
         # Remove columns that start with numbers
         if is_int(col[0]):


### PR DESCRIPTION
The most significant change here is in batch_unpack_from_supply_curve. I originally tried doing this:
`sc_developable_df = sc_df[sc_df['capacity'] > 0].reset_index(drop=True)`
That is fine but the runtime is the same. A significant improvement happens when we modify the sc_df in place. This looks safe since the function is only called from cli.py where the table is read in from a csv file and only used to feed into this batch_unpack_from_supply_curve function. So modifying it in place won't affect anything else. An increasing percentage of the runtime of this filter & reset_index work is saved as the df size increases. A further considerable improvement could be gained by setting `pd.options.mode.copy_on_write = True` which will be the default in Pandas 3 anyway. But that is too large of a change to make without being more familiar with this repository, so this pr does not change that Pandas option.

In `to_wgs` the del calls are not needed since the series are already being filtered on the self.df.column names anyway.

This change `n_workers = min(cpu_count(), n_workers)` was recommended by your linter.

And this call is also optionally routed through multiprocessing `all_turbines_df['geometry'] = all_turbines_df.apply(`

In characterizations.py, this .keys() is removed because iterating over a dictionary already iterates over the keys, so dict.keys() is almost never needed in Python. `columns=[c for c in col_df.columns if c not in lkup.keys()]`

`col_df.rename(` no need for the dictionary comprehension here since we can operate directly on the columns with `col_df.columns += "_area_sq_km"`

This creates 3 lists, 3 sets, and 1 dict_keys object, but none of these are necessary:
`    characterization_cols = list(characterization_remapper.keys())
    df_cols = supply_curve_df.columns.tolist()
    cols_not_in_df = list(set(characterization_cols).difference(set(df_cols)))`
Instead iterate of the dictionary and don't even make 1 list if it succeeds, and fail as soon as you hit a bad value if it fails:
`if any(key not in df.columns for key in characterization_remapper):`
Though in the failure case, you do have to make the list for the error message.

In functions.py, use str.translate to do multiple character replacements simultaneously. In the dictionaries passed to `str.make_trans` only the keys have to be single characters.

Using df.rename without inplace=True currently copies the *entire* dataframe. And doing this inside a loop meant that several copies of the whole df could be made if multiple columns got renamed. So change `df = df.rename({col: ncol}, axis=1)` to keeping a list of columns going outside of the loop and only updating the column names if needed with `df.columns = new_columns`.

Finally insert an element into the zeroth position in a list will cause all of the elements to have to be updated. So replace `values.insert(0, wkb)` with an iterable unpacking version of making the values list: `values = [wkb, *row.values]`