### PR TITLE
fixing version specification for pyarrow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 dash_bootstrap_components>=1.1.0,<2
 pygeopkg>=0.1.2,<1
-pyarrow~> 14.0.1
+pyarrow>=14.0.1,<14.1
 scikit-learn>=1.1.1,<2
 us>=2.0.2,<2.0.3
 plotext>=5.2.8,<5.3


### PR DESCRIPTION
This PR fixes the version specification for `pyarrow`, which was recently added as a dependency in requirements.txt. The prior version specification `~>` is not a valid specifier used by `pip`. 

Related, versions must be specified using the `>=,<` syntax in this library. The `~=` specifier is valid in `pip` but is not recognized by `conda`, but is effectively shorthand for the `>=,<` syntax.
